### PR TITLE
Fix: Rebuild site with correct Hugo base URL

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html lang="en" dir="auto">
 
-<head><script src="/recipes/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=recipes/livereload" data-no-instant defer></script><meta charset="utf-8">
+<head><meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="robots" content="noindex, nofollow">
+<meta name="robots" content="index, follow">
 <title>404 Page not found | Meine Rezeptsammlung</title>
 <meta name="keywords" content="">
 <meta name="description" content="Eine Sammlung meiner Lieblingsrezepte.">
 <meta name="author" content="Christian Plagens">
-<link rel="canonical" href="http://localhost:1313/recipes/404.html">
-<link crossorigin="anonymous" href="http://localhost:1313/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
-<link rel="icon" href="http://localhost:1313/recipes/favicon.ico">
-<link rel="icon" type="image/png" sizes="16x16" href="http://localhost:1313/recipes/favicon-16x16.png">
-<link rel="icon" type="image/png" sizes="32x32" href="http://localhost:1313/recipes/favicon-32x32.png">
-<link rel="apple-touch-icon" href="http://localhost:1313/recipes/apple-touch-icon.png">
-<link rel="mask-icon" href="http://localhost:1313/recipes/safari-pinned-tab.svg">
+<link rel="canonical" href="https://gem-cp.github.io/recipes/404.html">
+<link crossorigin="anonymous" href="https://gem-cp.github.io/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
+<link rel="icon" href="https://gem-cp.github.io/recipes/favicon.ico">
+<link rel="icon" type="image/png" sizes="16x16" href="https://gem-cp.github.io/recipes/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://gem-cp.github.io/recipes/favicon-32x32.png">
+<link rel="apple-touch-icon" href="https://gem-cp.github.io/recipes/apple-touch-icon.png">
+<link rel="mask-icon" href="https://gem-cp.github.io/recipes/safari-pinned-tab.svg">
 <meta name="theme-color" content="#2e2e33">
 <meta name="msapplication-TileColor" content="#2e2e33">
-<link rel="alternate" hreflang="en" href="http://localhost:1313/recipes/404.html">
+<link rel="alternate" hreflang="en" href="https://gem-cp.github.io/recipes/404.html">
 <noscript>
     <style>
         #theme-toggle,
@@ -55,7 +55,16 @@
         }
 
     </style>
-</noscript>
+</noscript><meta property="og:url" content="https://gem-cp.github.io/recipes/404.html">
+  <meta property="og:site_name" content="Meine Rezeptsammlung">
+  <meta property="og:title" content="404 Page not found">
+  <meta property="og:description" content="Eine Sammlung meiner Lieblingsrezepte.">
+  <meta property="og:locale" content="de-de">
+  <meta property="og:type" content="website">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="404 Page not found">
+<meta name="twitter:description" content="Eine Sammlung meiner Lieblingsrezepte.">
+
 </head>
 
 <body class="list" id="top">
@@ -73,7 +82,7 @@
 <header class="header">
     <nav class="nav">
         <div class="logo">
-            <a href="http://localhost:1313/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
+            <a href="https://gem-cp.github.io/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
             <div class="logo-switches">
                 <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
@@ -99,22 +108,22 @@
         </div>
         <ul id="menu">
             <li>
-                <a href="http://localhost:1313/asian/" title="Asiatische Rezepte">
+                <a href="https://gem-cp.github.io/asian/" title="Asiatische Rezepte">
                     <span>Asiatische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/german/" title=" Deutsche Rezepte">
+                <a href="https://gem-cp.github.io/german/" title=" Deutsche Rezepte">
                     <span> Deutsche Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/italian/" title=" Italienische Rezepte">
+                <a href="https://gem-cp.github.io/italian/" title=" Italienische Rezepte">
                     <span> Italienische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/tags/" title="Tags">
+                <a href="https://gem-cp.github.io/tags/" title="Tags">
                     <span>Tags</span>
                 </a>
             </li>
@@ -126,7 +135,7 @@
     </main>
     
 <footer class="footer">
-        <span>&copy; 2025 <a href="http://localhost:1313/recipes/">Meine Rezeptsammlung</a></span> · 
+        <span>&copy; 2025 <a href="https://gem-cp.github.io/recipes/">Meine Rezeptsammlung</a></span> ·
 
     <span>
         Powered by

--- a/public/categories/index.html
+++ b/public/categories/index.html
@@ -1,25 +1,25 @@
 <!DOCTYPE html>
 <html lang="en" dir="auto">
 
-<head><script src="/recipes/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=recipes/livereload" data-no-instant defer></script><meta charset="utf-8">
+<head><meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="robots" content="noindex, nofollow">
+<meta name="robots" content="index, follow">
 <title>Categories | Meine Rezeptsammlung</title>
 <meta name="keywords" content="">
 <meta name="description" content="Eine Sammlung meiner Lieblingsrezepte.">
 <meta name="author" content="Christian Plagens">
-<link rel="canonical" href="http://localhost:1313/recipes/categories/">
-<link crossorigin="anonymous" href="http://localhost:1313/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
-<link rel="icon" href="http://localhost:1313/recipes/favicon.ico">
-<link rel="icon" type="image/png" sizes="16x16" href="http://localhost:1313/recipes/favicon-16x16.png">
-<link rel="icon" type="image/png" sizes="32x32" href="http://localhost:1313/recipes/favicon-32x32.png">
-<link rel="apple-touch-icon" href="http://localhost:1313/recipes/apple-touch-icon.png">
-<link rel="mask-icon" href="http://localhost:1313/recipes/safari-pinned-tab.svg">
+<link rel="canonical" href="https://gem-cp.github.io/recipes/categories/">
+<link crossorigin="anonymous" href="https://gem-cp.github.io/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
+<link rel="icon" href="https://gem-cp.github.io/recipes/favicon.ico">
+<link rel="icon" type="image/png" sizes="16x16" href="https://gem-cp.github.io/recipes/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://gem-cp.github.io/recipes/favicon-32x32.png">
+<link rel="apple-touch-icon" href="https://gem-cp.github.io/recipes/apple-touch-icon.png">
+<link rel="mask-icon" href="https://gem-cp.github.io/recipes/safari-pinned-tab.svg">
 <meta name="theme-color" content="#2e2e33">
 <meta name="msapplication-TileColor" content="#2e2e33">
-<link rel="alternate" type="application/rss+xml" href="http://localhost:1313/recipes/categories/index.xml">
-<link rel="alternate" hreflang="en" href="http://localhost:1313/recipes/categories/">
+<link rel="alternate" type="application/rss+xml" href="https://gem-cp.github.io/recipes/categories/index.xml">
+<link rel="alternate" hreflang="en" href="https://gem-cp.github.io/recipes/categories/">
 <noscript>
     <style>
         #theme-toggle,
@@ -56,7 +56,16 @@
         }
 
     </style>
-</noscript>
+</noscript><meta property="og:url" content="https://gem-cp.github.io/recipes/categories/">
+  <meta property="og:site_name" content="Meine Rezeptsammlung">
+  <meta property="og:title" content="Categories">
+  <meta property="og:description" content="Eine Sammlung meiner Lieblingsrezepte.">
+  <meta property="og:locale" content="de-de">
+  <meta property="og:type" content="website">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Categories">
+<meta name="twitter:description" content="Eine Sammlung meiner Lieblingsrezepte.">
+
 </head>
 
 <body class="list" id="top">
@@ -74,7 +83,7 @@
 <header class="header">
     <nav class="nav">
         <div class="logo">
-            <a href="http://localhost:1313/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
+            <a href="https://gem-cp.github.io/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
             <div class="logo-switches">
                 <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
@@ -100,22 +109,22 @@
         </div>
         <ul id="menu">
             <li>
-                <a href="http://localhost:1313/asian/" title="Asiatische Rezepte">
+                <a href="https://gem-cp.github.io/asian/" title="Asiatische Rezepte">
                     <span>Asiatische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/german/" title=" Deutsche Rezepte">
+                <a href="https://gem-cp.github.io/german/" title=" Deutsche Rezepte">
                     <span> Deutsche Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/italian/" title=" Italienische Rezepte">
+                <a href="https://gem-cp.github.io/italian/" title=" Italienische Rezepte">
                     <span> Italienische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/tags/" title="Tags">
+                <a href="https://gem-cp.github.io/tags/" title="Tags">
                     <span>Tags</span>
                 </a>
             </li>
@@ -129,19 +138,19 @@
 
 <ul class="terms-tags">
     <li>
-        <a href="http://localhost:1313/recipes/categories/asiatisch/">Asiatisch <sup><strong><sup>4</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/categories/asiatisch/">Asiatisch <sup><strong><sup>4</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/categories/deutsch/">Deutsch <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/categories/deutsch/">Deutsch <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/categories/italienisch/">Italienisch <sup><strong><sup>2</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/categories/italienisch/">Italienisch <sup><strong><sup>2</sup></strong></sup> </a>
     </li>
 </ul>
     </main>
     
 <footer class="footer">
-        <span>&copy; 2025 <a href="http://localhost:1313/recipes/">Meine Rezeptsammlung</a></span> · 
+        <span>&copy; 2025 <a href="https://gem-cp.github.io/recipes/">Meine Rezeptsammlung</a></span> ·
 
     <span>
         Powered by

--- a/public/categories/index.xml
+++ b/public/categories/index.xml
@@ -2,31 +2,31 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>Categories on Meine Rezeptsammlung</title>
-    <link>http://localhost:1313/recipes/categories/</link>
+    <link>https://gem-cp.github.io/recipes/categories/</link>
     <description>Recent content in Categories on Meine Rezeptsammlung</description>
-    <generator>Hugo -- 0.148.0</generator>
+    <generator>Hugo -- 0.148.1</generator>
     <language>de-de</language>
     <lastBuildDate>Thu, 23 May 2024 00:00:00 +0000</lastBuildDate>
-    <atom:link href="http://localhost:1313/recipes/categories/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://gem-cp.github.io/recipes/categories/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Asiatisch</title>
-      <link>http://localhost:1313/recipes/categories/asiatisch/</link>
+      <link>https://gem-cp.github.io/recipes/categories/asiatisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/categories/asiatisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/categories/asiatisch/</guid>
       <description></description>
     </item>
     <item>
       <title>Deutsch</title>
-      <link>http://localhost:1313/recipes/categories/deutsch/</link>
+      <link>https://gem-cp.github.io/recipes/categories/deutsch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/categories/deutsch/</guid>
+      <guid>https://gem-cp.github.io/recipes/categories/deutsch/</guid>
       <description></description>
     </item>
     <item>
       <title>Italienisch</title>
-      <link>http://localhost:1313/recipes/categories/italienisch/</link>
+      <link>https://gem-cp.github.io/recipes/categories/italienisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/categories/italienisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/categories/italienisch/</guid>
       <description></description>
     </item>
   </channel>

--- a/public/index.html
+++ b/public/index.html
@@ -2,26 +2,26 @@
 <html lang="en" dir="auto">
 
 <head>
-	<meta name="generator" content="Hugo 0.148.0"><script src="/recipes/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=recipes/livereload" data-no-instant defer></script><meta charset="utf-8">
+	<meta name="generator" content="Hugo 0.148.1"><meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="robots" content="noindex, nofollow">
+<meta name="robots" content="index, follow">
 <title>Meine Rezeptsammlung</title>
 
 <meta name="description" content="Stöbere durch alle verfügbaren Rezepte, sortiert nach Kategorien.">
 <meta name="author" content="Christian Plagens">
-<link rel="canonical" href="http://localhost:1313/recipes/">
-<link crossorigin="anonymous" href="http://localhost:1313/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
-<link rel="icon" href="http://localhost:1313/recipes/favicon.ico">
-<link rel="icon" type="image/png" sizes="16x16" href="http://localhost:1313/recipes/favicon-16x16.png">
-<link rel="icon" type="image/png" sizes="32x32" href="http://localhost:1313/recipes/favicon-32x32.png">
-<link rel="apple-touch-icon" href="http://localhost:1313/recipes/apple-touch-icon.png">
-<link rel="mask-icon" href="http://localhost:1313/recipes/safari-pinned-tab.svg">
+<link rel="canonical" href="https://gem-cp.github.io/recipes/">
+<link crossorigin="anonymous" href="https://gem-cp.github.io/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
+<link rel="icon" href="https://gem-cp.github.io/recipes/favicon.ico">
+<link rel="icon" type="image/png" sizes="16x16" href="https://gem-cp.github.io/recipes/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://gem-cp.github.io/recipes/favicon-32x32.png">
+<link rel="apple-touch-icon" href="https://gem-cp.github.io/recipes/apple-touch-icon.png">
+<link rel="mask-icon" href="https://gem-cp.github.io/recipes/safari-pinned-tab.svg">
 <meta name="theme-color" content="#2e2e33">
 <meta name="msapplication-TileColor" content="#2e2e33">
-<link rel="alternate" type="application/rss+xml" href="http://localhost:1313/recipes/index.xml">
-<link rel="alternate" type="application/json" href="http://localhost:1313/recipes/index.json">
-<link rel="alternate" hreflang="en" href="http://localhost:1313/recipes/">
+<link rel="alternate" type="application/rss+xml" href="https://gem-cp.github.io/recipes/index.xml">
+<link rel="alternate" type="application/json" href="https://gem-cp.github.io/recipes/index.json">
+<link rel="alternate" hreflang="en" href="https://gem-cp.github.io/recipes/">
 <noscript>
     <style>
         #theme-toggle,
@@ -58,7 +58,29 @@
         }
 
     </style>
-</noscript>
+</noscript><meta property="og:url" content="https://gem-cp.github.io/recipes/">
+  <meta property="og:site_name" content="Meine Rezeptsammlung">
+  <meta property="og:title" content="Alle Rezepte">
+  <meta property="og:description" content="Stöbere durch alle verfügbaren Rezepte, sortiert nach Kategorien.">
+  <meta property="og:locale" content="de-de">
+  <meta property="og:type" content="website">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Alle Rezepte">
+<meta name="twitter:description" content="Stöbere durch alle verfügbaren Rezepte, sortiert nach Kategorien.">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Meine Rezeptsammlung",
+  "url": "https://gem-cp.github.io/recipes/",
+  "description": "Eine Sammlung meiner Lieblingsrezepte.",
+  "logo": "https://gem-cp.github.io/recipes/favicon.ico",
+  "sameAs": [
+
+  ]
+}
+</script>
 </head>
 
 <body class="list" id="top">
@@ -76,7 +98,7 @@
 <header class="header">
     <nav class="nav">
         <div class="logo">
-            <a href="http://localhost:1313/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
+            <a href="https://gem-cp.github.io/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
             <div class="logo-switches">
                 <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
@@ -102,22 +124,22 @@
         </div>
         <ul id="menu">
             <li>
-                <a href="http://localhost:1313/asian/" title="Asiatische Rezepte">
+                <a href="https://gem-cp.github.io/asian/" title="Asiatische Rezepte">
                     <span>Asiatische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/german/" title=" Deutsche Rezepte">
+                <a href="https://gem-cp.github.io/german/" title=" Deutsche Rezepte">
                     <span> Deutsche Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/italian/" title=" Italienische Rezepte">
+                <a href="https://gem-cp.github.io/italian/" title=" Italienische Rezepte">
                     <span> Italienische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/tags/" title="Tags">
+                <a href="https://gem-cp.github.io/tags/" title="Tags">
                     <span>Tags</span>
                 </a>
             </li>
@@ -133,7 +155,7 @@
 
 <article class="first-entry"> 
 <figure class="entry-cover">
-        <img loading="lazy" src="http://localhost:1313/images/gebratener-eierreis.png" alt="Gebratener Eierreis in einer Schale serviert">
+        <img loading="lazy" src="https://gem-cp.github.io/images/gebratener-eierreis.png" alt="Gebratener Eierreis in einer Schale serviert">
 </figure>
   <header class="entry-header">
     <h2 class="entry-hint-parent">Gebratener Eierreis wie im Asia-Restaurant
@@ -145,12 +167,12 @@ Zutaten Reis: Ca. 3 Tassen gekochter, kalter Reis (am besten vom Vortag, z.B. Ja
 ...</p>
   </div>
   <footer class="entry-footer"><span title='2024-05-23 00:00:00 +0000 UTC'>May 23, 2024</span>&nbsp;·&nbsp;Christian Plagens</footer>
-  <a class="entry-link" aria-label="post link to Gebratener Eierreis wie im Asia-Restaurant" href="http://localhost:1313/recipes/asian/gebratener-eierreis/"></a>
+  <a class="entry-link" aria-label="post link to Gebratener Eierreis wie im Asia-Restaurant" href="https://gem-cp.github.io/recipes/asian/gebratener-eierreis/"></a>
 </article>
 
 <article class="post-entry"> 
 <figure class="entry-cover">
-        <img loading="lazy" src="http://localhost:1313/images/chutneys.png" alt="Indische Chutneys in kleinen Schälchen">
+        <img loading="lazy" src="https://gem-cp.github.io/images/chutneys.png" alt="Indische Chutneys in kleinen Schälchen">
 </figure>
   <header class="entry-header">
     <h2 class="entry-hint-parent">Indische Chutneys
@@ -164,12 +186,12 @@ Name: Minze-Koriander-Chutney (Pudina Chutney / Dhaniya Chutney) Zubereitung: Fr
 ...</p>
   </div>
   <footer class="entry-footer"><span title='2024-05-23 00:00:00 +0000 UTC'>May 23, 2024</span>&nbsp;·&nbsp;Christian Plagens</footer>
-  <a class="entry-link" aria-label="post link to Indische Chutneys" href="http://localhost:1313/recipes/asian/chutneys/"></a>
+  <a class="entry-link" aria-label="post link to Indische Chutneys" href="https://gem-cp.github.io/recipes/asian/chutneys/"></a>
 </article>
 
 <article class="post-entry"> 
 <figure class="entry-cover">
-        <img loading="lazy" src="http://localhost:1313/images/palak-paneer.png" alt="Palak Paneer in einer Schale serviert">
+        <img loading="lazy" src="https://gem-cp.github.io/images/palak-paneer.png" alt="Palak Paneer in einer Schale serviert">
 </figure>
   <header class="entry-header">
     <h2 class="entry-hint-parent">Palak Paneer
@@ -181,7 +203,7 @@ Vorbereitungszeit: 20 Minuten Kochzeit: 30 Minuten Portionen: 3-4 Personen Zutat
 ...</p>
   </div>
   <footer class="entry-footer"><span title='2024-05-23 00:00:00 +0000 UTC'>May 23, 2024</span>&nbsp;·&nbsp;Christian Plagens</footer>
-  <a class="entry-link" aria-label="post link to Palak Paneer" href="http://localhost:1313/recipes/asian/palak-paneer/"></a>
+  <a class="entry-link" aria-label="post link to Palak Paneer" href="https://gem-cp.github.io/recipes/asian/palak-paneer/"></a>
 </article>
 
 <article class="post-entry"> 
@@ -195,12 +217,12 @@ Zubereitungszeit: ca. 15 Minuten Kochzeit: ca. 20-30 Minuten Portionen: 4
 Zutaten 1 EL Kokosöl oder Pflanzenöl 1 Zwiebel, gehackt 2 Knoblauchzehen, fein gehackt 1 Stück Ingwer (ca. 2 cm), gerieben 2-3 EL rote Thai-Currypaste (je nach gewünschter Schärfe) 400 ml Kokosmilch 250 ml Gemüsebrühe oder Wasser 500-600 g gemischtes Gemüse nach Wahl (z.B. Paprika, Zucchini, Thai-Auberginen (Eggplant), Karotten, Brokkoli, Zuckerschoten, Süßkartoffeln) 200 g fester Tofu, gewürfelt (optional) 1 Limette, Saft davon 1 EL Sojasauce Optional: 1 TL brauner Zucker Zum Servieren: frischer Koriander oder Thai-Basilikum, gehackte Erdnüsse, gekochter Jasmin- oder Basmatireis Anleitung Vorbereitung: Das gesamte Gemüse waschen und in mundgerechte Stücke schneiden. Den Tofu, falls verwendet, trocken tupfen und würfeln. Curry anbraten: Das Öl in einem großen Topf oder Wok bei mittlerer Hitze erhitzen. Die Zwiebel, den Knoblauch und den Ingwer darin glasig dünsten. Die rote Currypaste hinzugeben und für etwa eine Minute mitbraten, bis sie duftet. Ablöschen und köcheln: Mit der Kokosmilch und der Gemüsebrühe ablöschen und alles gut verrühren. Die Mischung zum Kochen bringen. Gemüse und Tofu garen: Das härtere Gemüse (wie Thai-Auberginen, Karotten und Süßkartoffeln) zuerst in die Sauce geben und etwa 5-7 Minuten köcheln lassen. Danach das weichere Gemüse (wie Paprika, Zucchini und Brokkoli) sowie den Tofu hinzufügen und weitere 5-10 Minuten garen, bis das Gemüse bissfest ist. Zuckerschoten erst in den letzten Minuten zugeben, damit sie knackig bleiben. Abschmecken: Das Curry mit Limettensaft, Sojasauce und optional etwas braunem Zucker abschmecken. Servieren: Das fertige Thai-Curry heiß mit Reis servieren und nach Belieben mit frischem Koriander oder Thai-Basilikum und gehackten Erdnüssen garnieren. Tipps für Variationen Currypaste: Statt roter kann auch gelbe oder grüne Currypaste verwendet werden. Gelbe Paste ist in der Regel milder, während grüne oft am schärfsten ist. Gemüse: Dieses Rezept ist ideal zur Resteverwertung. Es passen auch Pilze, grüne Bohnen, Pak Choi oder Spinat hervorragend dazu. Proteine: Anstelle von Tofu können auch Kichererbsen oder Linsen für eine zusätzliche Proteinquelle sorgen. Exotische Aromen: Für ein noch authentischeres Aroma können Kaffir-Limettenblätter und Zitronengras mit der Kokosmilch hinzugefügt und vor dem Servieren entfernt werden. Cremigkeit: Für eine extra cremige Sauce kann ein Löffel Erdnussbutter eingerührt werden. </p>
   </div>
   <footer class="entry-footer"><span title='2024-05-23 00:00:00 +0000 UTC'>May 23, 2024</span>&nbsp;·&nbsp;Christian Plagens</footer>
-  <a class="entry-link" aria-label="post link to Vegetarisches Thai Curry" href="http://localhost:1313/recipes/asian/thai-curry-vegetarisch/"></a>
+  <a class="entry-link" aria-label="post link to Vegetarisches Thai Curry" href="https://gem-cp.github.io/recipes/asian/thai-curry-vegetarisch/"></a>
 </article>
     </main>
     
 <footer class="footer">
-        <span>&copy; 2025 <a href="http://localhost:1313/recipes/">Meine Rezeptsammlung</a></span> · 
+        <span>&copy; 2025 <a href="https://gem-cp.github.io/recipes/">Meine Rezeptsammlung</a></span> ·
 
     <span>
         Powered by

--- a/public/index.xml
+++ b/public/index.xml
@@ -2,59 +2,59 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>Alle Rezepte on Meine Rezeptsammlung</title>
-    <link>http://localhost:1313/recipes/</link>
+    <link>https://gem-cp.github.io/recipes/</link>
     <description>Recent content in Alle Rezepte on Meine Rezeptsammlung</description>
-    <generator>Hugo -- 0.148.0</generator>
+    <generator>Hugo -- 0.148.1</generator>
     <language>de-de</language>
     <lastBuildDate>Thu, 23 May 2024 00:00:00 +0000</lastBuildDate>
-    <atom:link href="http://localhost:1313/recipes/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://gem-cp.github.io/recipes/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Brokkoli-Kartoffelauflauf</title>
-      <link>http://localhost:1313/recipes/german/brokkoli-kartoffel-auflauf/</link>
+      <link>https://gem-cp.github.io/recipes/german/brokkoli-kartoffel-auflauf/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/german/brokkoli-kartoffel-auflauf/</guid>
+      <guid>https://gem-cp.github.io/recipes/german/brokkoli-kartoffel-auflauf/</guid>
       <description>Ein cremiger und köstlicher vegetarischer Brokkoli-Kartoffelauflauf. Das perfekte Wohlfühlgericht für die ganze Familie, einfach zuzubereiten.</description>
     </item>
     <item>
       <title>Gebratener Eierreis wie im Asia-Restaurant</title>
-      <link>http://localhost:1313/recipes/asian/gebratener-eierreis/</link>
+      <link>https://gem-cp.github.io/recipes/asian/gebratener-eierreis/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/asian/gebratener-eierreis/</guid>
+      <guid>https://gem-cp.github.io/recipes/asian/gebratener-eierreis/</guid>
       <description>Ein einfaches Rezept für gebratenen Eierreis, wie man ihn aus dem Asia-Restaurant kennt. Schnell zubereitet und sehr lecker.</description>
     </item>
     <item>
       <title>Indische Chutneys</title>
-      <link>http://localhost:1313/recipes/asian/chutneys/</link>
+      <link>https://gem-cp.github.io/recipes/asian/chutneys/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/asian/chutneys/</guid>
+      <guid>https://gem-cp.github.io/recipes/asian/chutneys/</guid>
       <description>Eine Übersicht über typische indische Chutneys, die oft in Restaurants serviert werden, inklusive Minze-Koriander und Tamarinden Chutney.</description>
     </item>
     <item>
       <title>Klassische Lasagne al Forno</title>
-      <link>http://localhost:1313/recipes/italian/lasagne-al-forno/</link>
+      <link>https://gem-cp.github.io/recipes/italian/lasagne-al-forno/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/italian/lasagne-al-forno/</guid>
+      <guid>https://gem-cp.github.io/recipes/italian/lasagne-al-forno/</guid>
       <description>Ein traditionelles Rezept für eine herzhafte Lasagne, wie bei der Nonna. Mit Ragù alla Bolognese und Béchamelsauce.</description>
     </item>
     <item>
       <title>Palak Paneer</title>
-      <link>http://localhost:1313/recipes/asian/palak-paneer/</link>
+      <link>https://gem-cp.github.io/recipes/asian/palak-paneer/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/asian/palak-paneer/</guid>
+      <guid>https://gem-cp.github.io/recipes/asian/palak-paneer/</guid>
       <description>Ein klassisches nordindisches Gericht mit Paneer (indischer Frischkäse) in einer cremigen Spinatsauce. Vegetarisch und sehr beliebt.</description>
     </item>
     <item>
       <title>Vegetarisches Thai Curry</title>
-      <link>http://localhost:1313/recipes/asian/thai-curry-vegetarisch/</link>
+      <link>https://gem-cp.github.io/recipes/asian/thai-curry-vegetarisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/asian/thai-curry-vegetarisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/asian/thai-curry-vegetarisch/</guid>
       <description>Ein aromatisches und sättigendes vegetarisches Thai-Curry mit Kokosmilch, roter Currypaste und viel frischem Gemüse.</description>
     </item>
     <item>
       <title></title>
-      <link>http://localhost:1313/recipes/about/</link>
+      <link>https://gem-cp.github.io/recipes/about/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/about/</guid>
+      <guid>https://gem-cp.github.io/recipes/about/</guid>
       <description>&lt;h1 id=&#34;über-mich&#34;&gt;Über mich&lt;/h1&gt;
 &lt;p&gt;Ich bin ein leidenschaftlicher Koch und teile hier meine Lieblingsrezepte aus aller Welt. Viel Spaß beim Ausprobieren!&lt;/p&gt;
 &lt;h2 id=&#34;kontakt&#34;&gt;Kontakt&lt;/h2&gt;

--- a/public/page/1/index.html
+++ b/public/page/1/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="de-de">
   <head>
-    <title>http://localhost:1313/recipes/</title>
-    <link rel="canonical" href="http://localhost:1313/recipes/">
+    <title>https://gem-cp.github.io/recipes/</title>
+    <link rel="canonical" href="https://gem-cp.github.io/recipes/">
     <meta name="robots" content="noindex">
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=http://localhost:1313/recipes/">
+    <meta http-equiv="refresh" content="0; url=https://gem-cp.github.io/recipes/">
   </head>
 </html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,123 +2,123 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>http://localhost:1313/recipes/</loc>
+    <loc>https://gem-cp.github.io/recipes/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/categories/asiatisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/categories/asiatisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/asiatisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/asiatisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/asian/</loc>
+    <loc>https://gem-cp.github.io/recipes/asian/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/auflauf/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/auflauf/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/beilage/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/beilage/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/brokkoli/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/brokkoli/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/german/brokkoli-kartoffel-auflauf/</loc>
+    <loc>https://gem-cp.github.io/recipes/german/brokkoli-kartoffel-auflauf/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/categories/</loc>
+    <loc>https://gem-cp.github.io/recipes/categories/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/chutney/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/chutney/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/curry/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/curry/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/categories/deutsch/</loc>
+    <loc>https://gem-cp.github.io/recipes/categories/deutsch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/deutsch/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/deutsch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/german/</loc>
+    <loc>https://gem-cp.github.io/recipes/german/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/einfach/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/einfach/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/familienrezept/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/familienrezept/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/asian/gebratener-eierreis/</loc>
+    <loc>https://gem-cp.github.io/recipes/asian/gebratener-eierreis/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/hackfleisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/hackfleisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/hauptgericht/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/hauptgericht/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/indisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/indisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/asian/chutneys/</loc>
+    <loc>https://gem-cp.github.io/recipes/asian/chutneys/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/categories/italienisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/categories/italienisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/italienisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/italienisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/italian/</loc>
+    <loc>https://gem-cp.github.io/recipes/italian/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/kartoffeln/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/kartoffeln/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/klassiker/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/klassiker/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/italian/lasagne-al-forno/</loc>
+    <loc>https://gem-cp.github.io/recipes/italian/lasagne-al-forno/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/kokosmilch/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/kokosmilch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/asian/palak-paneer/</loc>
+    <loc>https://gem-cp.github.io/recipes/asian/palak-paneer/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/paneer/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/paneer/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/pasta/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/pasta/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/reis/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/reis/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/sauce/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/sauce/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/schnell/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/schnell/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/spinat/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/spinat/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/thai/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/thai/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/tags/vegetarisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/tags/vegetarisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/asian/thai-curry-vegetarisch/</loc>
+    <loc>https://gem-cp.github.io/recipes/asian/thai-curry-vegetarisch/</loc>
     <lastmod>2024-05-23T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>http://localhost:1313/recipes/about/</loc>
+    <loc>https://gem-cp.github.io/recipes/about/</loc>
   </url>
 </urlset>

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -1,25 +1,25 @@
 <!DOCTYPE html>
 <html lang="en" dir="auto">
 
-<head><script src="/recipes/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=recipes/livereload" data-no-instant defer></script><meta charset="utf-8">
+<head><meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="robots" content="noindex, nofollow">
+<meta name="robots" content="index, follow">
 <title>Tags | Meine Rezeptsammlung</title>
 <meta name="keywords" content="">
 <meta name="description" content="Eine Sammlung meiner Lieblingsrezepte.">
 <meta name="author" content="Christian Plagens">
-<link rel="canonical" href="http://localhost:1313/recipes/tags/">
-<link crossorigin="anonymous" href="http://localhost:1313/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
-<link rel="icon" href="http://localhost:1313/recipes/favicon.ico">
-<link rel="icon" type="image/png" sizes="16x16" href="http://localhost:1313/recipes/favicon-16x16.png">
-<link rel="icon" type="image/png" sizes="32x32" href="http://localhost:1313/recipes/favicon-32x32.png">
-<link rel="apple-touch-icon" href="http://localhost:1313/recipes/apple-touch-icon.png">
-<link rel="mask-icon" href="http://localhost:1313/recipes/safari-pinned-tab.svg">
+<link rel="canonical" href="https://gem-cp.github.io/recipes/tags/">
+<link crossorigin="anonymous" href="https://gem-cp.github.io/recipes/assets/css/stylesheet.8fe10233a706bc87f2e08b3cf97b8bd4c0a80f10675a143675d59212121037c0.css" integrity="sha256-j&#43;ECM6cGvIfy4Is8&#43;XuL1MCoDxBnWhQ2ddWSEhIQN8A=" rel="preload stylesheet" as="style">
+<link rel="icon" href="https://gem-cp.github.io/recipes/favicon.ico">
+<link rel="icon" type="image/png" sizes="16x16" href="https://gem-cp.github.io/recipes/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://gem-cp.github.io/recipes/favicon-32x32.png">
+<link rel="apple-touch-icon" href="https://gem-cp.github.io/recipes/apple-touch-icon.png">
+<link rel="mask-icon" href="https://gem-cp.github.io/recipes/safari-pinned-tab.svg">
 <meta name="theme-color" content="#2e2e33">
 <meta name="msapplication-TileColor" content="#2e2e33">
-<link rel="alternate" type="application/rss+xml" href="http://localhost:1313/recipes/tags/index.xml">
-<link rel="alternate" hreflang="en" href="http://localhost:1313/recipes/tags/">
+<link rel="alternate" type="application/rss+xml" href="https://gem-cp.github.io/recipes/tags/index.xml">
+<link rel="alternate" hreflang="en" href="https://gem-cp.github.io/recipes/tags/">
 <noscript>
     <style>
         #theme-toggle,
@@ -56,7 +56,16 @@
         }
 
     </style>
-</noscript>
+</noscript><meta property="og:url" content="https://gem-cp.github.io/recipes/tags/">
+  <meta property="og:site_name" content="Meine Rezeptsammlung">
+  <meta property="og:title" content="Tags">
+  <meta property="og:description" content="Eine Sammlung meiner Lieblingsrezepte.">
+  <meta property="og:locale" content="de-de">
+  <meta property="og:type" content="website">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Tags">
+<meta name="twitter:description" content="Eine Sammlung meiner Lieblingsrezepte.">
+
 </head>
 
 <body class="list" id="top">
@@ -74,7 +83,7 @@
 <header class="header">
     <nav class="nav">
         <div class="logo">
-            <a href="http://localhost:1313/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
+            <a href="https://gem-cp.github.io/recipes/" accesskey="h" title="Meine Rezeptsammlung (Alt + H)">Meine Rezeptsammlung</a>
             <div class="logo-switches">
                 <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
@@ -100,22 +109,22 @@
         </div>
         <ul id="menu">
             <li>
-                <a href="http://localhost:1313/asian/" title="Asiatische Rezepte">
+                <a href="https://gem-cp.github.io/asian/" title="Asiatische Rezepte">
                     <span>Asiatische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/german/" title=" Deutsche Rezepte">
+                <a href="https://gem-cp.github.io/german/" title=" Deutsche Rezepte">
                     <span> Deutsche Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/italian/" title=" Italienische Rezepte">
+                <a href="https://gem-cp.github.io/italian/" title=" Italienische Rezepte">
                     <span> Italienische Rezepte</span>
                 </a>
             </li>
             <li>
-                <a href="http://localhost:1313/tags/" title="Tags">
+                <a href="https://gem-cp.github.io/tags/" title="Tags">
                     <span>Tags</span>
                 </a>
             </li>
@@ -129,82 +138,82 @@
 
 <ul class="terms-tags">
     <li>
-        <a href="http://localhost:1313/recipes/tags/asiatisch/">Asiatisch <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/asiatisch/">Asiatisch <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/auflauf/">Auflauf <sup><strong><sup>2</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/auflauf/">Auflauf <sup><strong><sup>2</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/beilage/">Beilage <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/beilage/">Beilage <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/brokkoli/">Brokkoli <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/brokkoli/">Brokkoli <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/chutney/">Chutney <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/chutney/">Chutney <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/curry/">Curry <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/curry/">Curry <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/deutsch/">Deutsch <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/deutsch/">Deutsch <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/einfach/">Einfach <sup><strong><sup>2</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/einfach/">Einfach <sup><strong><sup>2</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/familienrezept/">Familienrezept <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/familienrezept/">Familienrezept <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/hackfleisch/">Hackfleisch <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/hackfleisch/">Hackfleisch <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/hauptgericht/">Hauptgericht <sup><strong><sup>6</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/hauptgericht/">Hauptgericht <sup><strong><sup>6</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/indisch/">Indisch <sup><strong><sup>2</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/indisch/">Indisch <sup><strong><sup>2</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/italienisch/">Italienisch <sup><strong><sup>2</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/italienisch/">Italienisch <sup><strong><sup>2</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/kartoffeln/">Kartoffeln <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/kartoffeln/">Kartoffeln <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/klassiker/">Klassiker <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/klassiker/">Klassiker <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/kokosmilch/">Kokosmilch <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/kokosmilch/">Kokosmilch <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/paneer/">Paneer <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/paneer/">Paneer <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/pasta/">Pasta <sup><strong><sup>2</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/pasta/">Pasta <sup><strong><sup>2</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/reis/">Reis <sup><strong><sup>3</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/reis/">Reis <sup><strong><sup>3</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/sauce/">Sauce <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/sauce/">Sauce <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/schnell/">Schnell <sup><strong><sup>2</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/schnell/">Schnell <sup><strong><sup>2</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/spinat/">Spinat <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/spinat/">Spinat <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/thai/">Thai <sup><strong><sup>1</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/thai/">Thai <sup><strong><sup>1</sup></strong></sup> </a>
     </li>
     <li>
-        <a href="http://localhost:1313/recipes/tags/vegetarisch/">Vegetarisch <sup><strong><sup>5</sup></strong></sup> </a>
+        <a href="https://gem-cp.github.io/recipes/tags/vegetarisch/">Vegetarisch <sup><strong><sup>5</sup></strong></sup> </a>
     </li>
 </ul>
     </main>
     
 <footer class="footer">
-        <span>&copy; 2025 <a href="http://localhost:1313/recipes/">Meine Rezeptsammlung</a></span> · 
+        <span>&copy; 2025 <a href="https://gem-cp.github.io/recipes/">Meine Rezeptsammlung</a></span> ·
 
     <span>
         Powered by

--- a/public/tags/index.xml
+++ b/public/tags/index.xml
@@ -2,178 +2,178 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>Tags on Meine Rezeptsammlung</title>
-    <link>http://localhost:1313/recipes/tags/</link>
+    <link>https://gem-cp.github.io/recipes/tags/</link>
     <description>Recent content in Tags on Meine Rezeptsammlung</description>
-    <generator>Hugo -- 0.148.0</generator>
+    <generator>Hugo -- 0.148.1</generator>
     <language>de-de</language>
     <lastBuildDate>Thu, 23 May 2024 00:00:00 +0000</lastBuildDate>
-    <atom:link href="http://localhost:1313/recipes/tags/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://gem-cp.github.io/recipes/tags/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Asiatisch</title>
-      <link>http://localhost:1313/recipes/tags/asiatisch/</link>
+      <link>https://gem-cp.github.io/recipes/tags/asiatisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/asiatisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/asiatisch/</guid>
       <description></description>
     </item>
     <item>
       <title>Auflauf</title>
-      <link>http://localhost:1313/recipes/tags/auflauf/</link>
+      <link>https://gem-cp.github.io/recipes/tags/auflauf/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/auflauf/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/auflauf/</guid>
       <description></description>
     </item>
     <item>
       <title>Beilage</title>
-      <link>http://localhost:1313/recipes/tags/beilage/</link>
+      <link>https://gem-cp.github.io/recipes/tags/beilage/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/beilage/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/beilage/</guid>
       <description></description>
     </item>
     <item>
       <title>Brokkoli</title>
-      <link>http://localhost:1313/recipes/tags/brokkoli/</link>
+      <link>https://gem-cp.github.io/recipes/tags/brokkoli/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/brokkoli/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/brokkoli/</guid>
       <description></description>
     </item>
     <item>
       <title>Chutney</title>
-      <link>http://localhost:1313/recipes/tags/chutney/</link>
+      <link>https://gem-cp.github.io/recipes/tags/chutney/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/chutney/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/chutney/</guid>
       <description></description>
     </item>
     <item>
       <title>Curry</title>
-      <link>http://localhost:1313/recipes/tags/curry/</link>
+      <link>https://gem-cp.github.io/recipes/tags/curry/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/curry/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/curry/</guid>
       <description></description>
     </item>
     <item>
       <title>Deutsch</title>
-      <link>http://localhost:1313/recipes/tags/deutsch/</link>
+      <link>https://gem-cp.github.io/recipes/tags/deutsch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/deutsch/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/deutsch/</guid>
       <description></description>
     </item>
     <item>
       <title>Einfach</title>
-      <link>http://localhost:1313/recipes/tags/einfach/</link>
+      <link>https://gem-cp.github.io/recipes/tags/einfach/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/einfach/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/einfach/</guid>
       <description></description>
     </item>
     <item>
       <title>Familienrezept</title>
-      <link>http://localhost:1313/recipes/tags/familienrezept/</link>
+      <link>https://gem-cp.github.io/recipes/tags/familienrezept/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/familienrezept/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/familienrezept/</guid>
       <description></description>
     </item>
     <item>
       <title>Hackfleisch</title>
-      <link>http://localhost:1313/recipes/tags/hackfleisch/</link>
+      <link>https://gem-cp.github.io/recipes/tags/hackfleisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/hackfleisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/hackfleisch/</guid>
       <description></description>
     </item>
     <item>
       <title>Hauptgericht</title>
-      <link>http://localhost:1313/recipes/tags/hauptgericht/</link>
+      <link>https://gem-cp.github.io/recipes/tags/hauptgericht/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/hauptgericht/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/hauptgericht/</guid>
       <description></description>
     </item>
     <item>
       <title>Indisch</title>
-      <link>http://localhost:1313/recipes/tags/indisch/</link>
+      <link>https://gem-cp.github.io/recipes/tags/indisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/indisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/indisch/</guid>
       <description></description>
     </item>
     <item>
       <title>Italienisch</title>
-      <link>http://localhost:1313/recipes/tags/italienisch/</link>
+      <link>https://gem-cp.github.io/recipes/tags/italienisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/italienisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/italienisch/</guid>
       <description></description>
     </item>
     <item>
       <title>Kartoffeln</title>
-      <link>http://localhost:1313/recipes/tags/kartoffeln/</link>
+      <link>https://gem-cp.github.io/recipes/tags/kartoffeln/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/kartoffeln/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/kartoffeln/</guid>
       <description></description>
     </item>
     <item>
       <title>Klassiker</title>
-      <link>http://localhost:1313/recipes/tags/klassiker/</link>
+      <link>https://gem-cp.github.io/recipes/tags/klassiker/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/klassiker/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/klassiker/</guid>
       <description></description>
     </item>
     <item>
       <title>Kokosmilch</title>
-      <link>http://localhost:1313/recipes/tags/kokosmilch/</link>
+      <link>https://gem-cp.github.io/recipes/tags/kokosmilch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/kokosmilch/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/kokosmilch/</guid>
       <description></description>
     </item>
     <item>
       <title>Paneer</title>
-      <link>http://localhost:1313/recipes/tags/paneer/</link>
+      <link>https://gem-cp.github.io/recipes/tags/paneer/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/paneer/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/paneer/</guid>
       <description></description>
     </item>
     <item>
       <title>Pasta</title>
-      <link>http://localhost:1313/recipes/tags/pasta/</link>
+      <link>https://gem-cp.github.io/recipes/tags/pasta/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/pasta/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/pasta/</guid>
       <description></description>
     </item>
     <item>
       <title>Reis</title>
-      <link>http://localhost:1313/recipes/tags/reis/</link>
+      <link>https://gem-cp.github.io/recipes/tags/reis/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/reis/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/reis/</guid>
       <description></description>
     </item>
     <item>
       <title>Sauce</title>
-      <link>http://localhost:1313/recipes/tags/sauce/</link>
+      <link>https://gem-cp.github.io/recipes/tags/sauce/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/sauce/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/sauce/</guid>
       <description></description>
     </item>
     <item>
       <title>Schnell</title>
-      <link>http://localhost:1313/recipes/tags/schnell/</link>
+      <link>https://gem-cp.github.io/recipes/tags/schnell/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/schnell/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/schnell/</guid>
       <description></description>
     </item>
     <item>
       <title>Spinat</title>
-      <link>http://localhost:1313/recipes/tags/spinat/</link>
+      <link>https://gem-cp.github.io/recipes/tags/spinat/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/spinat/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/spinat/</guid>
       <description></description>
     </item>
     <item>
       <title>Thai</title>
-      <link>http://localhost:1313/recipes/tags/thai/</link>
+      <link>https://gem-cp.github.io/recipes/tags/thai/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/thai/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/thai/</guid>
       <description></description>
     </item>
     <item>
       <title>Vegetarisch</title>
-      <link>http://localhost:1313/recipes/tags/vegetarisch/</link>
+      <link>https://gem-cp.github.io/recipes/tags/vegetarisch/</link>
       <pubDate>Thu, 23 May 2024 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/recipes/tags/vegetarisch/</guid>
+      <guid>https://gem-cp.github.io/recipes/tags/vegetarisch/</guid>
       <description></description>
     </item>
   </channel>


### PR DESCRIPTION
The GitHub Pages deployment was failing because the site was built with localhost URLs. This change rebuilds the site using the `hugo` command, which correctly applies the `baseURL` from `hugo.toml`.

This should fix the issues with missing images and the search function on the live site.